### PR TITLE
Add GitHub access token support and add API class

### DIFF
--- a/pr_reminder.rb
+++ b/pr_reminder.rb
@@ -9,7 +9,9 @@ class GitHubAPI
 
   def self.token
     if !@@api_token
-      if File.exists?(@@api_token_file)
+      if ENV['GH_API_TOKEN']
+        @@api_token = ENV['GH_API_TOKEN']
+      elsif File.exists?(@@api_token_file)
         @@api_token = File.open(@@api_token_file).read.gsub("\n", "")
       end
     end


### PR DESCRIPTION
It might make sense to allow the user to provide a GitHub access token (since there are some API call limitations for not authorized users).